### PR TITLE
Add support for beforeSubmit hook

### DIFF
--- a/src/MyForm.tsx
+++ b/src/MyForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import useForm from './use-form'
+import validatesPresense from './validations/validates-presence'
 
 const MyForm: React.FC = () => {
 
@@ -7,16 +8,17 @@ const MyForm: React.FC = () => {
     {
       name: {
         value: '',
-        validateOnSubmit: true
+        submitValidations: [validatesPresense()],
+        changeValidations: [validatesPresense()]
       },
       email: {
         value: '',
-        validateOnSubmit: true
+        submitValidations: [validatesPresense()],
+        changeValidations: [validatesPresense()]
       },
     },
     (e, fields) => {
       console.log('hello from consumer submit callback!', fields);
-      
     }
   );
   return (
@@ -24,11 +26,13 @@ const MyForm: React.FC = () => {
       <div>
         <label>Name:</label>
         <input type="text" name="name" value={fields.name.value} onChange={handleFieldChange} />
+        {fields.name.errors.map((error, i) => <span key={i}>{error}</span>)}
       </div>
 
       <div>
         <label>Email:</label>
         <input type="text" name="email" value={fields.email.value} onChange={handleFieldChange} />
+        {fields.email.errors.map((error, i) => <span key={i}>{error}</span>)}
       </div>
 
       <div>

--- a/src/use-form.test.js
+++ b/src/use-form.test.js
@@ -66,6 +66,7 @@ describe('useForm', () => {
       const hook = setupHook({
         startingValue: '',
         submitCb: submitSpy,
+        beforesubmit: () => {},
         submitValidations: [() => 'error message!']
       })
 
@@ -152,6 +153,19 @@ describe('useForm', () => {
     })
   })
 
+  describe('beforesubmit', () => {
+    it('calls function before submitting', () => {
+      const beforesubmitSpy = jest.fn()
+      const hook = setupHook({beforesubmit: beforesubmitSpy})
+
+      act(() => {
+        hook.current.handleOnSubmit(e)
+      })
+
+      expect(beforesubmitSpy).toHaveBeenCalledWith(e, hook.current.fields)
+    })
+  })
+
 })
 
 function setupHook(options) {
@@ -159,11 +173,12 @@ function setupHook(options) {
   const defaults = {
     startingValue: '', 
     submitCb: (_e, _fields) => {},
+    beforesubmit: (_e, _fields) => {},
     changeValidations: [],
     submitValidations: [],
   }
 
-  const {startingValue, submitCb, changeValidations, submitValidations} = Object.assign({}, defaults, options)
+  const {startingValue, submitCb, changeValidations, submitValidations, beforesubmit} = Object.assign({}, defaults, options)
 
   const {result} = renderHook(() => {
     return useForm(
@@ -174,7 +189,8 @@ function setupHook(options) {
           submitValidations,
         },
       },
-      submitCb
+      submitCb,
+      beforesubmit
     )
   });
 


### PR DESCRIPTION
API is extend to allow caller to supply an optional beforeSubmit callback. This function is called if supplied just before validating.