### PR TITLE
Add resolve function to submit callback

### DIFF
--- a/src/use-form.test.js
+++ b/src/use-form.test.js
@@ -59,7 +59,8 @@ describe('useForm', () => {
         hook.current.handleOnSubmit(e)
       })
 
-      expect(submitSpy).toHaveBeenCalledWith(e, hook.current.fields)
+      // not sure how to assert assert the signature of the function passed in.
+      expect(submitSpy).toHaveBeenCalledWith(e, hook.current.fields, expect.any(Function))
     })
 
     it('does not submit on invalid state', () => {
@@ -153,7 +154,7 @@ describe('useForm', () => {
     })
   })
 
-  describe('beforesubmit', () => {
+  describe('beforeSubmit', () => {
     it('calls function before submitting', () => {
       const beforesubmitSpy = jest.fn()
       const hook = setupHook({beforesubmit: beforesubmitSpy})
@@ -166,6 +167,53 @@ describe('useForm', () => {
     })
   })
 
+  describe('form state', () => {
+
+    it('initializes as "fresh"', () => {
+      const hook = setupHook();
+      expect(hook.current.status).toEqual('fresh')
+    })
+
+    it('has state "submitting" when submitting', () => {
+      const hook = setupHook({
+        submitCb: (e, fields, done) => {}
+      });
+
+      act(() => {
+        hook.current.handleOnSubmit(e)
+      })
+
+      expect(hook.current.status).toEqual('submitting');
+    })
+
+    it('has state "successful" when done callback given `true`', () => {
+      const hook = setupHook({
+        submitCb: (e, fields, done) => {
+          done(true)
+        }
+      });
+
+      act(() => {
+        hook.current.handleOnSubmit(e)
+      })
+
+      expect(hook.current.status).toEqual('successful');
+    })
+
+    it('has state "failed" when done callback given `false`', () => {
+      const hook = setupHook({
+        submitCb: (e, fields, done) => {
+          done(false)
+        }
+      });
+
+      act(() => {
+        hook.current.handleOnSubmit(e)
+      })
+
+      expect(hook.current.status).toEqual('failed');
+    })
+  })
 })
 
 function setupHook(options) {

--- a/src/use-form.ts
+++ b/src/use-form.ts
@@ -25,8 +25,15 @@ interface IFieldState {
 
 const useForm = <IFields extends BasicFields>(
   initialFields: IFields,
-  submitCb: (e: React.FormEvent<HTMLFormElement>, fields: IFieldState) => void,
-  beforeSubmit?: (e: React.FormEvent<HTMLFormElement>, fields: IFieldState) => void
+  submitCb: (
+    e: React.FormEvent<HTMLFormElement>,
+    fields: IFieldState,
+    resolve: (successful: boolean) => void
+  ) => void,
+  beforeSubmit?: (
+    e: React.FormEvent<HTMLFormElement>,
+    fields: IFieldState
+  ) => void
 ) => {
 
   const [fields, setFields] = useState(() => {
@@ -36,6 +43,8 @@ const useForm = <IFields extends BasicFields>(
     }, {} as IFieldState)
   })
 
+  const [status, setStatus] = useState<'fresh' | 'submitting' | 'successful' | 'failed'>('fresh')
+
   function handleOnSubmit(e: React.FormEvent<HTMLFormElement>) {
 
     // user supplied callback
@@ -44,7 +53,8 @@ const useForm = <IFields extends BasicFields>(
     if (beforeSubmit) beforeSubmit(e, fields);
     const canSubmit = validateSubmit()
     if (canSubmit) {
-      submitCb(e, fields)
+      setStatus('submitting');
+      submitCb(e, fields, resolve)
     }
   }
 
@@ -92,10 +102,19 @@ const useForm = <IFields extends BasicFields>(
     })
   }
 
+  function resolve(successful: boolean): void {
+    if (successful) {
+      setStatus('successful')
+    } else {
+      setStatus('failed')
+    }
+  }
+
   return {
     handleOnSubmit,
     handleFieldChange,
-    fields
+    fields,
+    status
   }
 }
 


### PR DESCRIPTION
The submit callback is now passed a function called `resolve`. The
caller passes a boolean to indicate if the form sent successfully.